### PR TITLE
Partial Razor Views for Templates

### DIFF
--- a/NBlog.Web/Application/Infrastructure/ThemeableRazorViewEngine.cs
+++ b/NBlog.Web/Application/Infrastructure/ThemeableRazorViewEngine.cs
@@ -10,16 +10,23 @@ namespace NBlog.Web.Application.Infrastructure
         public ThemeableRazorViewEngine(IThemeService themeService)
         {
             _themeService = themeService;
+
+            base.ViewLocationFormats = new[]
+            {
+                _themeService.Current.BasePath + "/Views/{1}/{0}.cshtml",
+                _themeService.Current.BasePath + "/Views/Shared/{0}.cshtml",
+                "~/Themes/Default/Views/{1}/{0}.cshtml"                
+            };
+
+            base.PartialViewLocationFormats = new string[] {
+                _themeService.Current.BasePath + "/Views/{1}/{0}.cshtml",
+                _themeService.Current.BasePath + "/Views/Shared/{0}.cshtml",
+                "~/Themes/Default/Views/Shared/{0}.cshtml"
+            };
         }
 
         public override ViewEngineResult FindView(ControllerContext controllerContext, string viewName, string masterName, bool useCache)
-        {
-            ViewLocationFormats = new[]
-            {
-                _themeService.Current.BasePath + "/Views/{1}/{0}.cshtml",
-                "~/Themes/Default/Views/{1}/{0}.cshtml"
-            };
-
+        {           
             // bypass the view cache, the view will change depending on the current theme
             const bool useViewCache = false;
 


### PR DESCRIPTION
Updated the ThemeableRazorViewEngine to look in a Shared directory beneath the current theme's view folder.
Defaults to partial page in the default theme if the partial doesn't exist in the current theme's directory.
